### PR TITLE
Fix/edit endpoint empty token saved

### DIFF
--- a/app/endpoints/(edit)/newEndpointForm.tsx
+++ b/app/endpoints/(edit)/newEndpointForm.tsx
@@ -163,10 +163,7 @@ function NewEndpointForm(props: NewEndpointFormProps) {
   });
 
   useEffect(() => {
-    if (!formik.dirty) return; // no change in form values
-    if (endpointToEdit) {
-      setDisableSaveBtn(!formik.isValid);
-    }
+    if (!formik.dirty) return;
     setDisableSaveBtn(!formik.isValid);
   }, [formik.dirty, endpointToEdit]);
 

--- a/app/endpoints/(edit)/newEndpointForm.tsx
+++ b/app/endpoints/(edit)/newEndpointForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useFormik } from 'formik';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 import { object, string, number, boolean } from 'yup';
 import { Icon, IconName } from '@/app/components/IconSVG';
 import { Button, ButtonType } from '@/app/components/button';
@@ -170,6 +170,13 @@ function NewEndpointForm(props: NewEndpointFormProps) {
     setDisableSaveBtn(!formik.isValid);
   }, [formik.dirty, endpointToEdit]);
 
+  const hasEmptyFields =
+    formik.values.name.trim() === '' ||
+    formik.values.connector_type.trim() === '' ||
+    formik.values.params?.trim() === '' ||
+    formik.values.token?.trim() === '';
+
+  console.log(hasEmptyFields);
   function handleTokenInputFocus(_: React.FocusEvent<HTMLInputElement>) {
     setTokenInputMode(TokenInputMode.EDITING);
     // note - backend api returns empty string if token is not set; it returns string of asterisks masking the token if token exists
@@ -412,7 +419,7 @@ function NewEndpointForm(props: NewEndpointFormProps) {
             />
             <Button
               width={120}
-              disabled={disableSaveBtn}
+              disabled={hasEmptyFields || disableSaveBtn}
               mode={ButtonType.PRIMARY}
               size="lg"
               type="submit"
@@ -470,6 +477,7 @@ function NewEndpointForm(props: NewEndpointFormProps) {
           </div>
           <div className="flex grow gap-2 justify-end items-end">
             <Button
+              disabled={!formik.values.params}
               width={120}
               mode={ButtonType.OUTLINE}
               size="lg"

--- a/app/endpoints/(edit)/newEndpointForm.tsx
+++ b/app/endpoints/(edit)/newEndpointForm.tsx
@@ -173,7 +173,6 @@ function NewEndpointForm(props: NewEndpointFormProps) {
     formik.values.params?.trim() === '' ||
     formik.values.token?.trim() === '';
 
-  console.log(hasEmptyFields);
   function handleTokenInputFocus(_: React.FocusEvent<HTMLInputElement>) {
     setTokenInputMode(TokenInputMode.EDITING);
     // note - backend api returns empty string if token is not set; it returns string of asterisks masking the token if token exists

--- a/app/endpoints/(edit)/newEndpointForm.tsx
+++ b/app/endpoints/(edit)/newEndpointForm.tsx
@@ -308,6 +308,11 @@ function NewEndpointForm(props: NewEndpointFormProps) {
               value={formik.values.connector_type}
               placeholder="Select the connector type"
               style={{ width: '100%' }}
+              error={
+                formik.touched.connector_type && formik.errors.connector_type
+                  ? formik.errors.connector_type
+                  : undefined
+              }
             />
 
             <TextInput

--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -86,7 +86,7 @@ type LLMEndpointFormValues = {
   connector_type: string;
   name: string;
   uri: string;
-  token: string;
+  token: string | undefined;
   max_calls_per_second: string;
   max_concurrency: string;
   params?: string;


### PR DESCRIPTION
## Description

Fixes the issue where updating endpoint without changing token value on the form, causes the token to be updated to empty string.
Also added codes to disable OK and Save buttons when required fields are empty

## Motivation and Context

[Explain the motivation or the context behind this pull request. Why is it necessary?]

## Type of Change

<!-- Select the appropriate type of change: -->
<!-- - feat: A new feature -->
- fix: A bug fix
<!-- - chore: Routine tasks, maintenance, or tooling changes -->
<!-- - docs: Documentation updates -->
<!-- - style: Code style changes (e.g., formatting, indentation) -->
<!-- - refactor: Code refactoring without changes in functionality -->
<!-- - test: Adding or modifying tests -->
<!-- - perf: Performance improvements -->
<!-- - ci: Changes to the CI/CD configuration or scripts -->
<!-- - other: Other changes that don't fit into the above categories -->

## How to Test

1. Go to Model Endpoints from left nav. Select an endpoint which already has token value and click `Edit Endpoint` button. Then focus mouse cursor on Token field and click `Save` button. Verify that the previous token value is not overwritten with empty string.
2.  When required fields are empty, verify `Save` button is disabled.
3. Do the same tests in `Run Benchmark` -> `Create Endpoint under Connect endpoint step`


## Checklist

Please check all the boxes that apply to this pull request using "x":

- [ x]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x ]  I have performed a self-review of my own code.
- [x ]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>