### PR TITLE
Fix endpoint save button not enabled when editing stock endpoint

### DIFF
--- a/app/endpoints/(edit)/_tests_/newEndpointForm.test.tsx
+++ b/app/endpoints/(edit)/_tests_/newEndpointForm.test.tsx
@@ -1,4 +1,4 @@
-import { screen, render } from '@testing-library/react';
+import { screen, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useRouter } from 'next/navigation';
 import { NewEndpointForm } from '@/app/endpoints/(edit)/newEndpointForm';
@@ -457,6 +457,69 @@ describe('NewEndpointForm', () => {
     await userEvent.click(tokenTextbox);
     expect(tokenTextbox).toHaveValue('');
     await userEvent.type(tokenTextbox, updatedToken);
+    await userEvent.click(saveBtn);
+    expect(mockUpdateModelEndpointSuccess).toHaveBeenCalledWith({
+      id: mockEndpoint.id,
+      endpointDetails: expectedPayloadWithToken,
+    });
+  }, 10000);
+
+  test('edit endpoint - form filling, no inital token value (default fresh install), new token added', async () => {
+    const mockUpdateModelEndpointSuccess = jest.fn().mockResolvedValue({});
+    (useUpdateLLMEndpointMutation as jest.Mock).mockImplementation(() => [
+      mockUpdateModelEndpointSuccess,
+      { isLoading: false },
+    ]);
+
+    const mockEndpoint: LLMEndpoint = {
+      id: 'mock-id',
+      connector_type: 'connector1',
+      name: 'mockname',
+      uri: 'mockuri',
+      token: '',
+      max_calls_per_second: 10,
+      max_concurrency: 1,
+      created_date: '2024-11-15T00:00:00.000Z',
+      params: {
+        timeout: 300,
+        allow_retries: true,
+        num_of_retries: 3,
+        temperature: 0.5,
+        model: 'mock-model',
+      },
+    };
+
+    const {
+      id: _,
+      token: __,
+      created_date: ___,
+      max_calls_per_second,
+      max_concurrency,
+      params,
+      ...restOfMockEndpoint
+    } = mockEndpoint;
+
+    const newToken = 'new-token';
+    const expectedPayloadWithToken = {
+      ...restOfMockEndpoint,
+      token: newToken,
+      name: mockEndpoint.name,
+      max_calls_per_second: String(max_calls_per_second),
+      max_concurrency: String(max_concurrency),
+      params: JSON.stringify(params, null, 2),
+    };
+
+    render(<NewEndpointForm endpointToEdit={mockEndpoint} />);
+
+    const nameTextbox = screen.getByDisplayValue(mockEndpoint.name);
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+    expect(saveBtn).toBeDisabled();
+
+    const tokenTextbox = screen.getByRole('textbox', {name: /token/i});
+    await userEvent.click(tokenTextbox);
+    expect(tokenTextbox).toHaveValue('');
+    await userEvent.type(tokenTextbox, newToken);
+    await waitFor(() => expect(saveBtn).toBeEnabled());
     await userEvent.click(saveBtn);
     expect(mockUpdateModelEndpointSuccess).toHaveBeenCalledWith({
       id: mockEndpoint.id,

--- a/app/endpoints/(edit)/newEndpointForm.tsx
+++ b/app/endpoints/(edit)/newEndpointForm.tsx
@@ -172,8 +172,10 @@ function NewEndpointForm(props: NewEndpointFormProps) {
   }, [data]);
 
   useEffect(() => {
-    if (endpointToEdit) return;
-    setDisableSaveBtn(!formik.isValid);
+    const handler = setTimeout(() => {
+      setDisableSaveBtn(!formik.isValid);
+    }, 300);
+    return () => clearTimeout(handler);
   }, [formik.isValid, endpointToEdit]);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

Edit endpoint form - Save button is not enabled when editing an endpoint that does not have api token value. This is the scenario for stock endpoints.

## Motivation and Context

Usability blocked

## Type of Change

<!-- Select the appropriate type of change: -->
<!-- - feat: A new feature -->
- fix: A bug fix
<!-- - chore: Routine tasks, maintenance, or tooling changes -->
<!-- - docs: Documentation updates -->
<!-- - style: Code style changes (e.g., formatting, indentation) -->
<!-- - refactor: Code refactoring without changes in functionality -->
<!-- - test: Adding or modifying tests -->
<!-- - perf: Performance improvements -->
<!-- - ci: Changes to the CI/CD configuration or scripts -->
<!-- - other: Other changes that don't fit into the above categories -->

## How to Test

1. Go to endpoints screen
2. Select an endpoint and click 'edit endpoint' button
Save button should be disabled by default and enabled when form values are changed. Also verify endpoint is updated when save button is clicked.

Regression required for new endpoint flow.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x ]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [x ]  I have added appropriate unit tests or functional tests for the changes made.
- [x ]  I have followed the project's coding conventions and style guidelines.
- [x ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x ]  I have performed a self-review of my own code.
- [x ]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>