### PR TITLE
optimize new/edit endpoint form input change

### DIFF
--- a/app/endpoints/(edit)/newEndpointForm.tsx
+++ b/app/endpoints/(edit)/newEndpointForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useFormik } from 'formik';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, memo } from 'react';
 import { object, string, number, boolean } from 'yup';
 import { Icon, IconName } from '@/app/components/IconSVG';
 import { Button, ButtonType } from '@/app/components/button';
@@ -19,6 +19,9 @@ import { LoadingAnimation } from '@/app/views/shared-components/loadingAnimation
 import { MainSectionSurface } from '@/app/views/shared-components/mainSectionSurface/mainSectionSurface';
 import { Modal } from '@/app/views/shared-components/modal/modal';
 import { PopupSurface } from '@/app/views/shared-components/popupSurface/popupSurface';
+
+//memoize
+const MemSelectInput = memo(SelectInput);
 
 const initialFormValues: LLMEndpointFormValues = {
   connector_type: '',
@@ -79,6 +82,13 @@ type NewEndpointFormProps = {
   disablePopupLayout?: boolean;
   onClose?: () => void;
 };
+
+const labelStyle: React.CSSProperties = {
+  fontSize: '1rem',
+  color: colors.moonpurplelight,
+};
+
+const inputStyle: React.CSSProperties = { height: 38 };
 
 enum TokenInputMode {
   EDITING = 'editing',
@@ -308,11 +318,8 @@ function NewEndpointForm(props: NewEndpointFormProps) {
             <TextInput
               name="name"
               label="Name*"
-              labelStyles={{
-                fontSize: '1rem',
-                color: colors.moonpurplelight,
-              }}
-              inputStyles={{ height: 38 }}
+              labelStyles={labelStyle}
+              inputStyles={inputStyle}
               onChange={formik.handleChange}
               value={formik.values.name}
               onBlur={formik.handleBlur}
@@ -324,19 +331,15 @@ function NewEndpointForm(props: NewEndpointFormProps) {
               placeholder="Name of the model"
             />
 
-            <SelectInput
-              label="Connection Type*"
+            <MemSelectInput
+              label="Connection TypeX*"
               name="connector_type"
-              labelStyles={{
-                fontSize: '1rem',
-                color: colors.moonpurplelight,
-              }}
-              inputStyle={{ height: 38 }}
+              labelStyles={labelStyle}
+              inputStyle={inputStyle}
               options={connectionTypeOptions}
               onSyntheticChange={formik.handleChange}
               value={formik.values.connector_type}
               placeholder="Select the connector type"
-              style={{ width: '100%' }}
               error={
                 formik.touched.connector_type && formik.errors.connector_type
                   ? formik.errors.connector_type
@@ -347,11 +350,8 @@ function NewEndpointForm(props: NewEndpointFormProps) {
             <TextInput
               name="uri"
               label="URI"
-              labelStyles={{
-                fontSize: '1rem',
-                color: colors.moonpurplelight,
-              }}
-              inputStyles={{ height: 38 }}
+              labelStyles={labelStyle}
+              inputStyles={inputStyle}
               onChange={formik.handleChange}
               value={formik.values.uri}
               onBlur={formik.handleBlur}
@@ -366,10 +366,7 @@ function NewEndpointForm(props: NewEndpointFormProps) {
             <TextInput
               name="token"
               label="Token"
-              labelStyles={{
-                fontSize: '1rem',
-                color: colors.moonpurplelight,
-              }}
+              labelStyles={labelStyle}
               inputStyles={
                 {
                   height: 38,
@@ -467,10 +464,10 @@ function NewEndpointForm(props: NewEndpointFormProps) {
                 fontSize: '1rem',
                 color: colors.moonpurplelight,
               }}
-              inputStyle={{ height: 38 }}
+              inputStyle={inputStyle}
             />
 
-            <SelectInput
+            <MemSelectInput
               id="max_concurrency"
               label="Max Concurrency"
               name="max_concurrency"
@@ -482,7 +479,7 @@ function NewEndpointForm(props: NewEndpointFormProps) {
                 fontSize: '1rem',
                 color: colors.moonpurplelight,
               }}
-              inputStyle={{ height: 38 }}
+              inputStyle={inputStyle}
             />
 
             <TextArea

--- a/app/endpoints/(edit)/newEndpointForm.tsx
+++ b/app/endpoints/(edit)/newEndpointForm.tsx
@@ -209,6 +209,49 @@ function NewEndpointForm(props: NewEndpointFormProps) {
     formik.values.params?.trim() === '' ||
     formik.values.token?.trim() === '';
 
+  const tokenTextboxValue = useMemo(() => {
+    // note - backend api returns empty string if token is not set; it returns string of asterisks masking the token if token exists
+    if (tokenInputMode === TokenInputMode.DEFAULT) {
+      // not editing the input, cursor is outside
+      if (endpointToEdit) {
+        // if EDITING AN ENDPOINT
+        if (
+          formik.values.token !== undefined &&
+          formik.values.token.trim() !== '' &&
+          formik.values.token.length > 0
+        ) {
+          // user has typed in an updated token string, populate with user input
+          return formik.values.token;
+        }
+        if (endpointToEdit.token.length > 0) {
+          formik.setFieldValue('token', endpointToEdit.token);
+          return endpointToEdit.token; // display the masked string if there is token
+        }
+        return ''; // populate with empty string if no token
+      }
+      // if CREATING A NEW ENDPOINT
+      return formik.values.token; // populate with user input (what user has entered)
+    }
+    if (tokenInputMode === TokenInputMode.EDITING) {
+      // if editing the input, cursor is inside (focused)
+      if (endpointToEdit) {
+        // if EDITING AN ENDPOINT
+        return formik.values.token; // populate with user input (what user has entered)
+      }
+      return formik.values.token; // populate with user input (what user has entered)
+    }
+  }, [tokenInputMode, endpointToEdit, formik.values.token]);
+
+  const tokenInputStyle = useMemo(() => {
+    return {
+      height: 38,
+      ...(isMaskTypedToken && {
+        WebkitTextSecurity: 'disc',
+        textSecurity: 'disc',
+      }),
+    } as React.CSSProperties;
+  }, [isMaskTypedToken]);
+
   function handleTokenInputFocus(_: React.FocusEvent<HTMLInputElement>) {
     setTokenInputMode(TokenInputMode.EDITING);
     // note - backend api returns empty string if token is not set; it returns string of asterisks masking the token if token exists
@@ -369,48 +412,9 @@ function NewEndpointForm(props: NewEndpointFormProps) {
               name="token"
               label="Token"
               labelStyles={labelStyle}
-              inputStyles={
-                {
-                  height: 38,
-                  ...(isMaskTypedToken && {
-                    WebkitTextSecurity: 'disc',
-                    textSecurity: 'disc',
-                  }),
-                } as React.CSSProperties
-              }
+              inputStyles={tokenInputStyle}
               onChange={formik.handleChange}
-              value={(() => {
-                // note - backend api returns empty string if token is not set; it returns string of asterisks masking the token if token exists
-                if (tokenInputMode === TokenInputMode.DEFAULT) {
-                  // not editing the input, cursor is outside
-                  if (endpointToEdit) {
-                    // if EDITING AN ENDPOINT
-                    if (
-                      formik.values.token !== undefined &&
-                      formik.values.token.trim() !== '' &&
-                      formik.values.token.length > 0
-                    ) {
-                      // user has typed in an updated token string, populate with user input
-                      return formik.values.token;
-                    }
-                    if (endpointToEdit.token.length > 0) {
-                      formik.setFieldValue('token', endpointToEdit.token);
-                      return endpointToEdit.token; // display the masked string if there is token
-                    }
-                    return ''; // populate with empty string if no token
-                  }
-                  // if CREATING A NEW ENDPOINT
-                  return formik.values.token; // populate with user input (what user has entered)
-                }
-                if (tokenInputMode === TokenInputMode.EDITING) {
-                  // if editing the input, cursor is inside (focused)
-                  if (endpointToEdit) {
-                    // if EDITING AN ENDPOINT
-                    return formik.values.token; // populate with user input (what user has entered)
-                  }
-                  return formik.values.token; // populate with user input (what user has entered)
-                }
-              })()}
+              value={tokenTextboxValue}
               onBlur={handleTokenInputBlur}
               onFocus={handleTokenInputFocus}
               error={

--- a/app/endpoints/(edit)/newEndpointForm.tsx
+++ b/app/endpoints/(edit)/newEndpointForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useFormik } from 'formik';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState, useRef, memo } from 'react';
+import { useEffect, useState, useRef, memo, useMemo } from 'react';
 import { object, string, number, boolean } from 'yup';
 import { Icon, IconName } from '@/app/components/IconSVG';
 import { Button, ButtonType } from '@/app/components/button';
@@ -20,7 +20,7 @@ import { MainSectionSurface } from '@/app/views/shared-components/mainSectionSur
 import { Modal } from '@/app/views/shared-components/modal/modal';
 import { PopupSurface } from '@/app/views/shared-components/popupSurface/popupSurface';
 
-//memoize
+//memoize select input - it is a complex component with many react elements, re-rendering it often is not efficient
 const MemSelectInput = memo(SelectInput);
 
 const initialFormValues: LLMEndpointFormValues = {
@@ -454,18 +454,14 @@ function NewEndpointForm(props: NewEndpointFormProps) {
       ) : (
         <div className="w-[100%] flex justify-between">
           <div className="flex flex-col w-[50%] gap-2">
-            <SelectInput
+            <MemSelectInput
               id="max_calls_per_second"
               label="Max Calls Per Second"
               name="max_calls_per_second"
               options={maxCallsPerSecondOptions}
               onSyntheticChange={formik.handleChange}
               value={formik.values.max_calls_per_second}
-              style={{ width: '100%' }}
-              labelStyles={{
-                fontSize: '1rem',
-                color: colors.moonpurplelight,
-              }}
+              labelStyles={labelStyle}
               inputStyle={inputStyle}
             />
 
@@ -476,11 +472,7 @@ function NewEndpointForm(props: NewEndpointFormProps) {
               options={maxConcurrencyOptions}
               onSyntheticChange={formik.handleChange}
               value={formik.values.max_concurrency}
-              style={{ width: '100%' }}
-              labelStyles={{
-                fontSize: '1rem',
-                color: colors.moonpurplelight,
-              }}
+              labelStyles={labelStyle}
               inputStyle={inputStyle}
             />
 
@@ -491,10 +483,7 @@ function NewEndpointForm(props: NewEndpointFormProps) {
               value={formik.values.params}
               error={formik.errors.params ? formik.errors.params : undefined}
               placeholder="Additional parameters normally in JSON format"
-              labelStyles={{
-                fontSize: '1rem',
-                color: colors.moonpurplelight,
-              }}
+              labelStyles={labelStyle}
               inputStyles={{ height: 200 }}
             />
           </div>


### PR DESCRIPTION
## Description

The form runs javascript on every textbox and selectbox input change, for input validations and enabling/disabling of save button. The  selectbox component is a complex one with a lot of react elements in it. Re-rendering it on every input change is not efficient.

Code changes done to memoize the selectbox component in this form. Also memoize couple of other calculated values.

Before memoize - form re-render at around 2ms
![endpointform1](https://github.com/user-attachments/assets/3b479778-8039-4012-9230-1d653b538e85)


After - form re-render at sub millisecond
![endpointform2](https://github.com/user-attachments/assets/599375ed-5acf-4d06-9ae1-5ad11c8f4bbc)

## Motivation and Context

Improved performance of the new/edit endpoint form

## Type of Change

<!-- Select the appropriate type of change: -->
<!-- - feat: A new feature -->
<!-- - fix: A bug fix -->
- chore: Routine tasks, maintenance, or tooling changes
<!-- - docs: Documentation updates -->
<!-- - style: Code style changes (e.g., formatting, indentation) -->
<!-- - refactor: Code refactoring without changes in functionality -->
<!-- - test: Adding or modifying tests -->
<!-- - perf: Performance improvements -->
<!-- - ci: Changes to the CI/CD configuration or scripts -->
<!-- - other: Other changes that don't fit into the above categories -->

## How to Test

[Provide clear instructions on how to test and verify the changes introduced by this pull request, including any specific unit tests you have created to demonstrate your changes.]

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [ ]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [ ]  I have performed a self-review of my own code.
- [ ]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>