### PR TITLE
resolve mismatched calculation of number of prompt sent to model

### DIFF
--- a/app/benchmarking/components/__tests__/benchmarkRunForm.test.tsx
+++ b/app/benchmarking/components/__tests__/benchmarkRunForm.test.tsx
@@ -67,53 +67,83 @@ const GRAND_TOTAL_PROMPTS = totalPromptsForStat0 + totalPromptForStat1;
 const USER_INPUT_PERCENTAGE_OF_PROMPTS = 5;
 const DECIMAL_FRACTION_OF_PROMPTS = USER_INPUT_PERCENTAGE_OF_PROMPTS / 100;
 const SMALLER_SET_TOTAL_PROMPTS =
-  Math.floor(
-    DECIMAL_FRACTION_OF_PROMPTS *
-      mockRecipesStats[0].num_of_datasets_prompts.dataset1 //mockRecipesStats[0] has 0 prompt templates
+  Math.max(
+    1,
+    Math.floor(
+      DECIMAL_FRACTION_OF_PROMPTS *
+        mockRecipesStats[0].num_of_datasets_prompts.dataset1 //mockRecipesStats[0] has 0 prompt templates
+    )
   ) +
-  Math.floor(
-    DECIMAL_FRACTION_OF_PROMPTS *
-      mockRecipesStats[0].num_of_datasets_prompts.dataset2 //mockRecipesStats[0] has 0 prompt templates
+  Math.max(
+    1,
+    Math.floor(
+      DECIMAL_FRACTION_OF_PROMPTS *
+        mockRecipesStats[0].num_of_datasets_prompts.dataset2 //mockRecipesStats[0] has 0 prompt templates
+    )
   ) +
-  Math.floor(
-    DECIMAL_FRACTION_OF_PROMPTS *
-      mockRecipesStats[1].num_of_datasets_prompts.dataset1
+  Math.max(
+    1,
+    Math.floor(
+      DECIMAL_FRACTION_OF_PROMPTS *
+        mockRecipesStats[1].num_of_datasets_prompts.dataset1
+    )
   ) *
     mockRecipesStats[1].num_of_prompt_templates +
-  Math.floor(
-    DECIMAL_FRACTION_OF_PROMPTS *
-      mockRecipesStats[1].num_of_datasets_prompts.dataset2
+  Math.max(
+    1,
+    Math.floor(
+      DECIMAL_FRACTION_OF_PROMPTS *
+        mockRecipesStats[1].num_of_datasets_prompts.dataset2
+    )
   ) *
     mockRecipesStats[1].num_of_prompt_templates +
-  Math.floor(
-    DECIMAL_FRACTION_OF_PROMPTS *
-      mockRecipesStats[1].num_of_datasets_prompts.dataset3
+  Math.max(
+    1,
+    Math.floor(
+      DECIMAL_FRACTION_OF_PROMPTS *
+        mockRecipesStats[1].num_of_datasets_prompts.dataset3
+    )
   ) *
     mockRecipesStats[1].num_of_prompt_templates;
 
 const ONE_PERCENT_DECIMAL_FRACTION = 1 / 100;
 const ONE_PERCENT_TOTAL_PROMPTS =
-  Math.floor(
-    ONE_PERCENT_DECIMAL_FRACTION *
-      mockRecipesStats[0].num_of_datasets_prompts.dataset1 //mockRecipesStats[0] has 0 prompt templates
+  Math.max(
+    1,
+    Math.floor(
+      ONE_PERCENT_DECIMAL_FRACTION *
+        mockRecipesStats[0].num_of_datasets_prompts.dataset1 //mockRecipesStats[0] has 0 prompt templates
+    )
   ) +
-  Math.floor(
-    ONE_PERCENT_DECIMAL_FRACTION *
-      mockRecipesStats[0].num_of_datasets_prompts.dataset2
+  Math.max(
+    1,
+    Math.floor(
+      ONE_PERCENT_DECIMAL_FRACTION *
+        mockRecipesStats[0].num_of_datasets_prompts.dataset2
+    )
   ) +
-  Math.floor(
-    ONE_PERCENT_DECIMAL_FRACTION *
-      mockRecipesStats[1].num_of_datasets_prompts.dataset1
+  Math.max(
+    1,
+    Math.floor(
+      ONE_PERCENT_DECIMAL_FRACTION *
+        mockRecipesStats[1].num_of_datasets_prompts.dataset1
+    )
   ) *
     mockRecipesStats[1].num_of_prompt_templates +
-  Math.floor(
-    ONE_PERCENT_DECIMAL_FRACTION *
-      mockRecipesStats[1].num_of_datasets_prompts.dataset2
+  Math.max(
+    1,
+    Math.floor(
+      ONE_PERCENT_DECIMAL_FRACTION *
+        mockRecipesStats[1].num_of_datasets_prompts.dataset2
+    )
   ) *
     mockRecipesStats[1].num_of_prompt_templates +
-  Math.floor(
-    ONE_PERCENT_DECIMAL_FRACTION *
-      mockRecipesStats[1].num_of_datasets_prompts.dataset3
+  Math.max(
+    1,
+    Math.floor(
+      ONE_PERCENT_DECIMAL_FRACTION *
+        mockRecipesStats[1].num_of_datasets_prompts.dataset3
+    )
   ) *
     mockRecipesStats[1].num_of_prompt_templates;
 

--- a/app/benchmarking/components/benchmarkRunForm.tsx
+++ b/app/benchmarking/components/benchmarkRunForm.tsx
@@ -60,9 +60,9 @@ function BenchmarkRunForm({
             stats.num_of_datasets_prompts
           ).reduce((sum, value) => {
             if (calcPercentageAtEachDataset) {
-              percentageCalculatedTotalPrompts += Math.floor(
+              percentageCalculatedTotalPrompts += Math.max(1, Math.floor(
                 value * decimalFraction
-              );
+              ));
             }
             return sum + value;
           }, 0);

--- a/app/benchmarking/components/benchmarkRunStatus.tsx
+++ b/app/benchmarking/components/benchmarkRunStatus.tsx
@@ -129,9 +129,9 @@ function BenchmarkRunStatus({ allStatuses }: { allStatuses: TestStatuses }) {
         stats.num_of_datasets_prompts
       ).reduce((sum, value) => {
         if (calcPercentageAtEachDataset) {
-          percentageCalculatedTotalPrompts += Math.floor(
+          percentageCalculatedTotalPrompts += Math.max(1, Math.floor(
             value * decimalFraction
-          );
+          ));
         }
         return sum + value;
       }, 0);


### PR DESCRIPTION
## Description

There is a mismatch in the no-of-prompt calculation between the frontend and backend. 

- For frontend, the initial implementation is to take the floor(percentage * number of prompts) for each recipe. 
- However, this causes certain datasets to have 0 prompts.
- Backend's implementation is to take a minimum of 1 prompt per recipe. 

Solution:

- Match backend's implementation to take at least 1 from every recipe

## Motivation and Context

Align the frontend and backend implementation to accurately show the number of prompts sent. 

## Type of Change

- fix: A bug fix

## How to Test

1. Pick your datasets
2. Set the % of prompts to be 2%
      a. Remember the number of prompts indicated
![image](https://github.com/user-attachments/assets/0863604e-401d-4e55-9f04-51d90f3d2324)

3. Run the benchmarking run
![image](https://github.com/user-attachments/assets/8510bbad-9aef-4b8f-9205-a9635bb9d3ec)


5. Check that the number of prompts in 2a aligns with the number of prompts indicated in the report
![image](https://github.com/user-attachments/assets/0863604e-401d-4e55-9f04-51d90f3d2324)



## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [x]  I have added or updated the necessary documentation (README, API docs, etc.).
- [x]  I have added appropriate unit tests or functional tests for the changes made.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [x]  I have squashed or reorganized my commits into logical units.
- [x]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>